### PR TITLE
Fix service monitor matching labels

### DIFF
--- a/deployment/charts/ovh-mks-exporter/templates/servicemonitor.yaml
+++ b/deployment/charts/ovh-mks-exporter/templates/servicemonitor.yaml
@@ -16,5 +16,5 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-    {{- include "ovh-mks-exporter.selectorLabels" . | nindent 4 }}
+      {{- include "ovh-mks-exporter.selectorLabels" . | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
Actually this template generate

```
  selector:
    app.kubernetes.io/instance: ovh-mks-exporter
    app.kubernetes.io/name: ovh-mks-exporter
    matchLabels: null
```

instead of 

```
  selector:
    matchLabels:
      app.kubernetes.io/instance: ovh-mks-exporter
      app.kubernetes.io/name: ovh-mks-exporter
```

So deployment is break because crd not match correctly, this error is generated :
`.spec.selector.app.kubernetes.io/instance: field not declared in schema`

Just add missing indentation to fix