### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/rverchere/ovh-mks-exporter/security/code-scanning/2](https://github.com/rverchere/ovh-mks-exporter/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/go-test.yml` at the workflow root (after the `on` block, before `jobs`).  
For this workflow, the minimal required permission is:

- `contents: read` (needed for `actions/checkout` and repository read operations)

No additional scopes are required for running tests or uploading artifacts to GitHub Actions artifacts.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
