### PR TITLE
Match Plumber badge style to the other badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![ci](https://github.com/rverchere/ovh-mks-exporter/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/rverchere/ovh-mks-exporter/actions/workflows/docker-publish.yml)
 [![ci](https://github.com/rverchere/ovh-mks-exporter/actions/workflows/go-releaser.yml/badge.svg)](https://github.com/rverchere/ovh-mks-exporter/actions/workflows/go-releaser.yml)
 [![tests](https://github.com/rverchere/ovh-mks-exporter/actions/workflows/go-test.yml/badge.svg)](https://github.com/rverchere/ovh-mks-exporter/actions/workflows/go-test.yml)
-[![Plumber Score](https://score.getplumber.io/github.com/rverchere/ovh-mks-exporter.svg)](https://score.getplumber.io/github.com/rverchere/ovh-mks-exporter)
+[![Plumber Score](https://score.getplumber.io/github.com/rverchere/ovh-mks-exporter.svg?style=flat)](https://score.getplumber.io/github.com/rverchere/ovh-mks-exporter)
 
 [![Docker Stars](https://img.shields.io/docker/stars/rverchere/ovh-mks-exporter.svg?style=flat)](https://hub.docker.com/r/rverchere/ovh-mks-exporter/)
 [![Docker Pulls](https://img.shields.io/docker/pulls/rverchere/ovh-mks-exporter.svg?style=flat)](https://hub.docker.com/r/rverchere/ovh-mks-exporter/)


### PR DESCRIPTION
Re 👋

Bien vu pour le badge Plumber : il était rendu en style « for-the-badge » (28px de haut), du coup plus grand que tes badges CI. Ce petit fix ajoute `?style=flat` pour qu'il ait la même taille que les autres (20px). Désolé pour le dérangement !
