### PR TITLE
Update Plumber to v0.3.86 (security fix)

### DIFF
--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: getplumber/plumber@3c06bb97568d4f0cdd35e63356a05a134647659e # v0.3.84
+      - uses: getplumber/plumber@a697e9c316b058d279861719c73b87093fb5a60f # v0.3.86
         with:
           threshold: 60      # fail under a 60% Plumber Score
           score-push: true   # publishes a public Plumber Score badge


### PR DESCRIPTION
Hi 👋

I'm from the Plumber team. This repo pins the `getplumber/plumber` action in CI, and the version here is affected by a security issue we've just fixed (everything `<= 0.3.85`).

This PR bumps the pinned action to **v0.3.86** (SHA-pinned), which contains the fix.

We're not sharing the details publicly yet, a full advisory will be published soon. In the meantime we'd recommend updating promptly. Happy to answer anything.

Thanks! 🙏
